### PR TITLE
Added `purrr` library to fix `map()` code

### DIFF
--- a/zebra_app/app.R
+++ b/zebra_app/app.R
@@ -18,6 +18,7 @@ library(plotly)
 library(tidyr)
 library(tibble)
 library(ggbeeswarm)
+library(purrr)
 options(shiny.maxRequestSize = 30*1024^2)
 
 ui <- page_sidebar(


### PR DESCRIPTION
# Purpose

What is the purpose of this pull request?
All plots/tables using `map()` were breaking

What GitHub issue (if any) does your pull request address?
Issue #11 

# Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.

Please run app and make sure that broken plots/tables are working now

# Results

The following should now work:
- Statistical summary
- Peak Height Table
- Peak Height Plot
- Pre-Peak Activity Slope
- Post-Peak Activity Slope
